### PR TITLE
unsmush

### DIFF
--- a/banners.css
+++ b/banners.css
@@ -41,7 +41,7 @@
 
 #ucsf-banner-nav ul, #ucsf-banner-nav li {
     display: inline;
-    margin: 0;
+    margin: 0 0 0 2em;
     padding: 0;
 }
 
@@ -49,7 +49,6 @@
     color: #ffffff;
     display: inline;
     text-decoration: none;
-    margin-left: 2em;
 }
 
 #ucsf-banner-nav a:hover {

--- a/banners.css
+++ b/banners.css
@@ -49,6 +49,7 @@
     color: #ffffff;
     display: inline;
     text-decoration: none;
+    margin-left: 2em;
 }
 
 #ucsf-banner-nav a:hover {


### PR DESCRIPTION
Links in banner are squeezed together. This gives them a little breathing room. It might require some adjustments on the media queries, or perhaps not.
